### PR TITLE
Define java source set for Android view

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -34,6 +34,10 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
+
+    sourceSets {
+       main.java.srcDirs += 'src/main/kotlin'
+   }
 }
 
 dependencies {

--- a/mobile/build.gradle
+++ b/mobile/build.gradle
@@ -62,6 +62,10 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
+
+    sourceSets {
+       main.java.srcDirs += 'src/main/kotlin'
+   }
 }
 
 dependencies {

--- a/wear/build.gradle
+++ b/wear/build.gradle
@@ -60,6 +60,10 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
+
+    sourceSets {
+       main.java.srcDirs += 'src/main/kotlin'
+   }
 }
 
 dependencies {


### PR DESCRIPTION
When importing this project into Android Studio, I noticed that the Android view doesn't show any source code. In order to make kotlin files appear there, a `sourceSet` needs to be defined.

Sources:
[Kotlin on Android Studio](https://developer.android.com/kotlin/get-started.html)